### PR TITLE
Add unique index on posts slug

### DIFF
--- a/db/migrations/20171229211302_create_post_slug_index.cr
+++ b/db/migrations/20171229211302_create_post_slug_index.cr
@@ -1,0 +1,9 @@
+class CreatePostSlugIndex::V20171229211302 < LuckyMigrator::Migration::V1
+  def migrate
+    create_index :posts, :slug, unique: true
+  end
+
+  def rollback
+    drop_index :posts, :slug
+  end
+end

--- a/spec/feed_spec.cr
+++ b/spec/feed_spec.cr
@@ -34,7 +34,7 @@ describe Blog::Feed do
 
     context "more than five posts" do
       it "adds a next_url link" do
-        (PostQuery::PER_PAGE + 1).times { |i| insert_post title: i.to_s  }
+        (PostQuery::PER_PAGE + 1).times { |i| insert_post title: i.to_s }
 
         response = visitor.visit("/feed.json", headers)
 

--- a/spec/feed_spec.cr
+++ b/spec/feed_spec.cr
@@ -34,7 +34,7 @@ describe Blog::Feed do
 
     context "more than five posts" do
       it "adds a next_url link" do
-        (PostQuery::PER_PAGE + 1).times { insert_post }
+        (PostQuery::PER_PAGE + 1).times { |i| insert_post title: i.to_s  }
 
         response = visitor.visit("/feed.json", headers)
 
@@ -42,7 +42,7 @@ describe Blog::Feed do
       end
 
       it "does not show a next_url when on the last page" do
-        (PostQuery::PER_PAGE + 1).times { insert_post }
+        (PostQuery::PER_PAGE + 1).times { |i| insert_post title: i.to_s }
 
         response = visitor.visit("/feed.json?page=2", headers)
 

--- a/spec/queries/post_query_spec.cr
+++ b/spec/queries/post_query_spec.cr
@@ -95,9 +95,9 @@ describe PostQuery do
     end
 
     it "only returns matching posts" do
-      insert_post content: "matcher", published_at: Time.now - 2.days
-      insert_post content: "a match this", published_at: Time.now - 1.days
-      insert_post published_at: Time.now - 1.days
+      insert_post title: "title 1", content: "matcher", published_at: Time.now - 2.days
+      insert_post title: "title 2", content: "a match this", published_at: Time.now - 1.days
+      insert_post title: "title 3", published_at: Time.now - 1.days
 
       posts = PostQuery.new.published_search("match").results
 

--- a/spec/queries/post_query_spec.cr
+++ b/spec/queries/post_query_spec.cr
@@ -20,13 +20,19 @@ describe PostQuery do
     end
 
     it "shows 5 posts at most" do
-      10.times { insert_post }
+      10.times { |i| insert_post title: i.to_s }
       PostQuery.new.latest.results.size.should eq 5
     end
 
     it "accepts a page param" do
-      7.times { insert_post }
+      7.times { |i| insert_post title: i.to_s }
       PostQuery.new.latest(page: 2).results.size.should eq 2
+    end
+
+    it "can be counted" do
+      PostQuery.new.latest.count.should eq 0
+      2.times { |i| insert_post title: i.to_s }
+      PostQuery.new.latest.count.should eq 2
     end
   end
 

--- a/spec/queries/post_query_spec.cr
+++ b/spec/queries/post_query_spec.cr
@@ -28,12 +28,6 @@ describe PostQuery do
       7.times { |i| insert_post title: i.to_s }
       PostQuery.new.latest(page: 2).results.size.should eq 2
     end
-
-    it "can be counted" do
-      PostQuery.new.latest.count.should eq 0
-      2.times { |i| insert_post title: i.to_s }
-      PostQuery.new.latest.count.should eq 2
-    end
   end
 
   describe "#published" do


### PR DESCRIPTION
- [x] Is this actually beneficial in any way? Data Integrity (no duplicate slugs possible)? Speed (query by slug)?
  