### PR TITLE
Move permalink hash into css pseudo

### DIFF
--- a/spec/blog_spec.cr
+++ b/spec/blog_spec.cr
@@ -16,8 +16,8 @@ describe Blog do
 
       visitor.visit("/")
 
-      visitor.should contain "Sample post<a href=\"/posts/sample-post\">#</a>"
-      visitor.should contain "Lorem ipsum<a href=\"/posts/lorem-ipsum\">#</a>"
+      visitor.should contain "Sample post<a href=\"/posts/sample-post\"></a>"
+      visitor.should contain "Lorem ipsum<a href=\"/posts/lorem-ipsum\"></a>"
     end
 
     it "shows the second page of posts" do

--- a/src/components/blog/posts/components.cr
+++ b/src/components/blog/posts/components.cr
@@ -9,7 +9,7 @@ module Blog::Posts::Components
       header class: "post-title" do
         h2 do
           text post.title
-          link "#", to: Blog::Posts::Show.with(post.slug)
+          link "", to: Blog::Posts::Show.with(post.slug)
         end
         post_meta(post)
       end

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -126,6 +126,10 @@ a:hover {
     padding-left: 10px;
 }
 
+.post-title a:before {
+    content: '#';
+}
+
 .post-title:hover a:link {
     opacity: 1;
 }


### PR DESCRIPTION


The reader view in e.g. Safari strips css but keeps all the text, which
makes for a weird dangling hash.