### PR TITLE
Force using my custom domain.

### DIFF
--- a/spec/handlers/force_custom_domain_handler_spec.cr
+++ b/spec/handlers/force_custom_domain_handler_spec.cr
@@ -1,0 +1,45 @@
+require "../spec_helper"
+
+describe ForceCustomDomainHandler do
+  it "redirects to the custom domain when the heroku domain is requested" do
+    req = request(host: "hannesdotkaeuflerdotnet.herokuapp.com")
+    context = HTTP::Server::Context.new(req, response)
+
+    middlewares.call context
+
+    context.response.status_code.should eq 301
+    context.response.headers["Location"].should eq Lucky::RouteHelper.settings.base_uri
+  end
+
+  it "simply calls the next handler when the custom domain is already used" do
+    req = request(host: "https://hannes.kaeufler.net")
+    context = HTTP::Server::Context.new(req, response)
+    last = FakeHandler.new
+
+    middlewares(last: last).call context
+
+    last.was_called.should eq true
+  end
+end
+
+class FakeHandler
+  include HTTP::Handler
+  @was_called = false
+  getter was_called
+
+  def call(context)
+    @was_called = true
+  end
+end
+
+def middlewares(last = FakeHandler.new)
+  HTTP::Server.build_middleware([ForceCustomDomainHandler.new, last])
+end
+
+def response
+  response = HTTP::Server::Response.new(IO::Memory.new)
+end
+
+def request(host : String)
+  HTTP::Request.new("GET", "/", headers: HTTP::Headers{"host" => host})
+end

--- a/spec/handlers/force_custom_domain_handler_spec.cr
+++ b/spec/handlers/force_custom_domain_handler_spec.cr
@@ -37,7 +37,7 @@ def middlewares(last = FakeHandler.new)
 end
 
 def response
-  response = HTTP::Server::Response.new(IO::Memory.new)
+  HTTP::Server::Response.new(IO::Memory.new)
 end
 
 def request(host : String)

--- a/src/handlers/force_custom_domain_handler.cr
+++ b/src/handlers/force_custom_domain_handler.cr
@@ -1,0 +1,12 @@
+class ForceCustomDomainHandler
+  include HTTP::Handler
+
+  def call(context)
+    if context.request.host =~ /herokuapp\.com/
+      context.response.status_code = 301
+      context.response.headers["Location"] = Lucky::RouteHelper.settings.base_uri
+    else
+      call_next(context)
+    end
+  end
+end

--- a/src/server.cr
+++ b/src/server.cr
@@ -4,6 +4,7 @@ host = Lucky::Server.settings.host
 port = Lucky::Server.settings.port
 
 server = HTTP::Server.new([
+  ForceCustomDomainHandler.new,
   Lucky::HttpMethodOverrideHandler.new,
   Lucky::LogHandler.new,
   Lucky::SessionHandler.new,


### PR DESCRIPTION
Heroku also answers via hannesdotkaeuflerdotnet.herokuapp.com, however for analytics I dont want that. It must redirect to hannes.kaeufler.net on ssl for sure